### PR TITLE
Split structures into sizing and positioning algorithms

### DIFF
--- a/src/components/SettingsOptions.vue
+++ b/src/components/SettingsOptions.vue
@@ -58,11 +58,10 @@
           <div class="field">
             <div class="select">
               <div class="control">
-                <select v-model="structure">
-                  <option>Simple</option>
-                  <option>Size-Scaled</option>
-                  <option>Spiral</option>
+                <select v-model="positionAlgorithm">
                   <option>Automatic</option>
+                  <option>Circular</option>
+                  <option>Spiral</option>
                 </select>
               </div>
             </div>
@@ -196,10 +195,6 @@ export default Vue.extend({
       get() { return this.$store.state.settings.automatic },
       set(value) { this.setting({ prop: 'automatic', value }) },
     },
-    structure: {
-      get() { return this.$store.state.settings.structure },
-      set(value) { this.setting({ prop: 'structure', value }) },
-    },
     width: {
       get() { return this.$store.state.settings.width },
       set(value) { this.setting({ prop: 'width', value }) },
@@ -231,6 +226,10 @@ export default Vue.extend({
     sizeScaling: {
       get() { return this.$store.state.settings.config.sizeScaling },
       set(value) { this.setting({ prop: 'config.sizeScaling', value }) },
+    },
+    positionAlgorithm: {
+      get() { return this.$store.state.settings.config.positionAlgorithm },
+      set(value) { this.setting({ prop: 'config.positionAlgorithm', value }) },
     },
   }
 })

--- a/src/components/SettingsOptions.vue
+++ b/src/components/SettingsOptions.vue
@@ -23,6 +23,34 @@
       <div class="field is-horizontal">
         <div class="field-label is-normal">
           <label class="label">
+            Size scaling
+          </label>
+        </div>
+        <div class="field-body">
+          <div class="field has-addons">
+            <div class="control">
+              <input type="range"
+                     class="input"
+                     min="0"
+                     max="2"
+                     step="0.01"
+                     v-model="sizeScaling">
+            </div>
+            <div class="control">
+              <input type="number"
+                     class="input"
+                     min="0"
+                     max="2"
+                     step="0.01"
+                     v-model="sizeScaling">
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="field is-horizontal">
+        <div class="field-label is-normal">
+          <label class="label">
             Structure
           </label>
         </div>
@@ -86,10 +114,22 @@
         </div>
         <div class="field-body">
           <div class="field">
-            <div class="control">
+            <div class="control is-expanded">
               <input type="color"
                      class="input"
                      v-model="foregroundColour">
+            </div>
+          </div>
+          <div class="field has-addons">
+            <div class="control">
+              <a class="button is-static">
+                alpha
+              </a>
+            </div>
+            <div class="control">
+              <input type="number"
+                     class="input alpha"
+                     v-model="foregroundAlpha">
             </div>
           </div>
         </div>
@@ -103,10 +143,22 @@
         </div>
         <div class="field-body">
           <div class="field">
-            <div class="control">
+            <div class="control is-expanded">
               <input type="color"
                      class="input"
                      v-model="backgroundColour">
+            </div>
+          </div>
+          <div class="field has-addons">
+            <div class="control">
+              <a class="button is-static">
+                alpha
+              </a>
+            </div>
+            <div class="control">
+              <input type="number"
+                     class="input alpha"
+                     v-model="backgroundAlpha">
             </div>
           </div>
         </div>
@@ -160,13 +212,25 @@ export default Vue.extend({
       get() { return this.$store.state.settings.foregroundColour },
       set(value) { this.setting({ prop: 'foregroundColour', value }) },
     },
+    foregroundAlpha: {
+      get() { return this.$store.state.settings.foregroundAlpha },
+      set(value) { this.setting({ prop: 'foregroundAlpha', value }) },
+    },
     backgroundColour: {
       get() { return this.$store.state.settings.backgroundColour },
       set(value) { this.setting({ prop: 'backgroundColour', value }) },
     },
+    backgroundAlpha: {
+      get() { return this.$store.state.settings.backgroundAlpha },
+      set(value) { this.setting({ prop: 'backgroundAlpha', value }) },
+    },
     debug: {
       get() { return this.$store.state.settings.debug },
       set(value) { this.setting({ prop: 'debug', value }) },
+    },
+    sizeScaling: {
+      get() { return this.$store.state.settings.config.sizeScaling },
+      set(value) { this.setting({ prop: 'config.sizeScaling', value }) },
     },
   }
 })
@@ -175,5 +239,13 @@ export default Vue.extend({
 <style lang="scss">
 .field-body {
   flex-grow: 2;
+}
+
+input[type=color] {
+  min-width: 2.5em;
+}
+
+.alpha {
+  max-width: 4rem;
 }
 </style>

--- a/src/functions/geometry.ts
+++ b/src/functions/geometry.ts
@@ -4,7 +4,6 @@ import { Sentence, Word } from '@/types/phrases'
 export function calculateSubphraseGeometry(
   sentence: Sentence,
   w: number, // XXX only used as index
-  structure: string, // the selected structure type
   relativeAngularSizeSum: number, // the sum of relative angles
   settings: Settings,
 ): void {
@@ -21,8 +20,20 @@ export function calculateSubphraseGeometry(
    * @returns void; Modifies the subphrase in place to add x, y, radius, and
    * angularLocation
    */
-  // half of that angle, for some reason
-  if (structure === "Simple" || structure === "Size-Scaled") {
+
+  let structure = settings.config.positionAlgorithm
+
+  // If the positioning algorithm is marked as automatic, pick the best one
+  if (structure === 'Automatic') {
+    if (sentence.phrases.length > 8) {
+      structure = 'Spiral'
+    } else {
+      structure = 'Circular'
+    }
+  }
+
+  if (structure === 'Circular') {
+    // The basic algorithm with everything subtending angles of a circle
     // Calculate the angle subtended by the subphrase's radius
     const radialSubtension = sentence.phrases[w].absoluteAngularSize! / 2
     if (sentence.phrases.length > 1) {
@@ -60,7 +71,7 @@ export function calculateSubphraseGeometry(
     sentence.phrases[w].x = sentence.x! + translate.x
     sentence.phrases[w].y = sentence.y! + translate.y
 
-  } else if (structure === "Spiral") {
+  } else if (structure === 'Spiral') {
     // For long sentences is is likely appropriate to place each word on the
     // path of a spiral, to avoid excessive wasted space in the middle of the
     // circle.
@@ -103,25 +114,6 @@ export function calculateSubphraseGeometry(
     sentence.phrases[w].x = sentence.x! + coords[0]
     sentence.phrases[w].y = sentence.y! + coords[1]
 
-  } else if (structure === "Automatic") {
-    if (
-      sentence.phrases.length < settings.config.automatic.scaledLessThan
-    ) {
-      structure = "Size-Scaled"
-    } else if (
-      sentence.phrases.length > settings.config.automatic.spiralMoreThan
-    ) {
-      structure = "Spiral"
-    } else {
-      structure = "Simple"
-    }
-    calculateSubphraseGeometry(
-      sentence,
-      w,
-      structure,
-      relativeAngularSizeSum,
-      settings
-    )
   }
 }
 

--- a/src/functions/render/sentence.ts
+++ b/src/functions/render/sentence.ts
@@ -24,11 +24,9 @@ export function renderSentence(
   sentence.phrases.forEach((phrase: Sentence | Word) => {
     if(Array.isArray(phrase.phrases)){
       // This is a word
-      if (settings.structure == "Size-Scaled"){
-        phrase.relativeAngularSize = phrase.phrases.length
-      } else {
-        phrase.relativeAngularSize = 1
-      }
+      phrase.relativeAngularSize = Math.pow(
+        phrase.phrases.length, settings.config.sizeScaling
+      )
     } else {
       // This is a buffer
       phrase.relativeAngularSize = settings.config.buffer.phrase
@@ -57,7 +55,6 @@ export function renderSentence(
     calculateSubphraseGeometry(
       sentence,
       subphrase,
-      settings.structure,
       relativeAngularSizeSum,
       settings,
     )

--- a/src/store.ts
+++ b/src/store.ts
@@ -18,7 +18,6 @@ export default new Vuex.Store({
     settings: {
       splits: [ "\n\n", "\n", " " ],
       selectedAlphabets: ["base", "Sherman", "ShermanVowels"],
-      structure: "Automatic",
       scaling: true, // sentence size scaling
       watermark: true,
       debug: false,

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,7 +25,9 @@ export default new Vuex.Store({
       automatic: true,
       width: 1024,
       foregroundColour: "#000000",
+      foregroundAlpha: 0,
       backgroundColour: "#FFFFFF",
+      backgroundAlpha: 1,
       config: {
         s: { height: 0.9, width: 1 },
         p: { height: 1.2, width: 1 },
@@ -35,6 +37,8 @@ export default new Vuex.Store({
         word: { height: 1.2, width: 1 },
         buffer: { letter: 0.5, phrase: 0.3 },
         automatic: { scaledLessThan: 6, spiralMoreThan: 9 },
+        sizeScaling: 0,
+        positionAlgorithm: 'Circular',
       },
     },
   } as State,

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -27,12 +27,13 @@ export type Settings = {
   debug: boolean
   width: number
   foregroundColour: string
+  foregroundAlpha: number
   backgroundColour: string
+  backgroundAlpha: number
   config: Config
 }
 
 export type Config = {
-  // TODO work out what the FUCK these mean
   s: BlockConfig
   p: BlockConfig
   d: BlockConfig
@@ -41,7 +42,7 @@ export type Config = {
   word: BlockConfig
   buffer: BufferConfig
   automatic: AutomaticConfig
-  sizeDependenceOnLength: number
+  sizeScaling: number
   positionAlgorithm: 'Circular' | 'Spiral'
 }
 

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -43,7 +43,7 @@ export type Config = {
   buffer: BufferConfig
   automatic: AutomaticConfig
   sizeScaling: number
-  positionAlgorithm: 'Circular' | 'Spiral'
+  positionAlgorithm: 'Automatic' | 'Circular' | 'Spiral'
 }
 
 export type BlockConfig = {

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -22,7 +22,6 @@ export type State = {
 export type Settings = {
   splits: string[]
   selectedAlphabets: string[]
-  structure: string
   scaling: boolean
   watermark: boolean
   debug: boolean
@@ -42,6 +41,8 @@ export type Config = {
   word: BlockConfig
   buffer: BufferConfig
   automatic: AutomaticConfig
+  sizeDependenceOnLength: number
+  positionAlgorithm: 'Circular' | 'Spiral'
 }
 
 export type BlockConfig = {


### PR DESCRIPTION
- [ ] Fix #39 by splitting structures into sizes and positions
- [ ] Implement this in the UI
And fuck it, while we're here:
- [ ] Fix #37 by keeping the buffer ratio constant despite increases in average `relativeAngularSize`
- [ ] Implement a "choose automatically" setting for at least one of the two new things (probably positioning?)

I should consider having a unified sizing mode where the dependence of the size on the length of its term varies. Simple would be 0 and Size-Scaled would be 1, probably.