### PR TITLE
Collisions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gallifreyo",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4071,6 +4071,12 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "detect-collisions": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/detect-collisions/-/detect-collisions-2.5.2.tgz",
+      "integrity": "sha512-zspZQAKr1gDuBQ7of2sxqYzu+anus1hSGErvNzmKFEpz9KllG/NSXTRp1oirYCNQMKVMJTELtlsBLpK9Hm0wCg==",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "core-js": "^3.6.5",
     "css-loader": "^3.5.3",
+    "detect-collisions": "^2.5.2",
     "eslint": "^7.1.0",
     "eslint-plugin-vue": "^6.2.2",
     "html-webpack-plugin": "^4.3.0",

--- a/src/collisions/CollisionsTest.vue
+++ b/src/collisions/CollisionsTest.vue
@@ -1,0 +1,44 @@
+<template>
+  <div id="app">
+    <div>
+      <label>
+        <input type="checkbox"
+               v-model="wantsBvh"
+               @change="changeBvh()"
+               id="show-bounding-box">
+        Show Bounding Volume Hierarchy boxes
+      </label>
+    </div>
+    <div>
+      <button>
+        Reset
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue"
+
+import { GrowingCirclesTest } from '@/collisions/circles'
+
+export default Vue.extend({
+  name: "CollisionsTest",
+  data() {
+    return {
+      test: new GrowingCirclesTest(),
+      canvas: null as null | HTMLCanvasElement,
+      wantsBvh: false,
+    }
+  },
+  methods: {
+    changeBvh: function () {
+      this.test.wantsBvh = this.wantsBvh
+    }
+  },
+  mounted() {
+    this.canvas = this.test.canvas
+    document.getElementById("app")!.appendChild(this.canvas)
+  },
+})
+</script>

--- a/src/collisions/CollisionsTest.vue
+++ b/src/collisions/CollisionsTest.vue
@@ -10,7 +10,7 @@
       </label>
     </div>
     <div>
-      <button>
+      <button @click="reset">
         Reset
       </button>
     </div>
@@ -34,6 +34,9 @@ export default Vue.extend({
   methods: {
     changeBvh: function () {
       this.test.wantsBvh = this.wantsBvh
+    },
+    reset: function () {
+      this.test.createCircles()
     }
   },
   mounted() {

--- a/src/collisions/circles.ts
+++ b/src/collisions/circles.ts
@@ -1,0 +1,104 @@
+import { Collisions, Circle, Result } from "detect-collisions"
+import { range } from "lodash"
+
+const width = 600
+const height = width
+const count = 50
+const speed = 1
+const result = new Collisions().createResult()
+const circleRes = 12
+
+export class GrowingCirclesTest {
+  element: HTMLDivElement
+  canvas: HTMLCanvasElement
+  context: CanvasRenderingContext2D
+  collisions: Collisions
+  result: Result
+  bodies: Circle[]
+  frame: number
+  wantsBvh: boolean
+
+  constructor() {
+    this.element = document.createElement('div')
+    this.canvas = document.createElement('canvas')
+    this.context = this.canvas.getContext('2d')!
+    this.collisions = new Collisions()
+    this.result = this.collisions.createResult()
+    this.bodies = []
+    this.wantsBvh = false
+
+    this.canvas.width = width
+    this.canvas.height = height
+
+    // Create the containing circle out of lines
+    const circlePoints = range(0, circleRes).map(index => {
+      const angle = index * 2 * Math.PI / circleRes - Math.PI / 2
+      return [
+        Math.cos(angle) * width/2 + width/2,
+        Math.sin(angle) * width/2 + width/2,
+      ]
+    })
+    circlePoints.forEach((thisPoint, index) => {
+      const nextIndex = index == circleRes - 1 ? 0 : index + 1
+      const nextPoint = circlePoints[nextIndex]
+      this.collisions.createPolygon(0, 0, [thisPoint, nextPoint])
+    })
+
+    const nextFrame = () => {
+      this.update()
+      this.frame = requestAnimationFrame(nextFrame)
+    }
+
+    this.frame = requestAnimationFrame(nextFrame)
+  }
+
+  update(): void {
+    this.collisions.update()
+
+    this.bodies.forEach(body => {
+      body.x += body.direction_x * speed
+      body.y += body.direction_y * speed
+
+      const potentials = body.potentials()
+
+      for (const body2 of potentials) {
+        if (body.collides(body2, result)) {
+          body.x -= result.overlap * result.overlap_x
+          body.y -= result.overlap * result.overlap_y
+
+          let dot = body.direction_x * result.overlap_y + body.direction_y * -result.overlap_x
+
+          body.direction_x = 2 * dot * result.overlap_y - body.direction_x
+          body.direction_y = 2 * dot * -result.overlap_x - body.direction_y
+
+          dot = body2.direction_x * result.overlap_y + body2.direction_y * -result.overlap_x
+
+          body2.direction_x = 2 * dot * result.overlap_y - body2.direction_x
+          body2.direction_y = 2 * dot * -result.overlap_x - body2.direction_y
+        }
+      }
+    })
+
+    // Clear the canvas
+    this.context.fillStyle = '#000000'
+    this.context.fillRect(0, 0, width, height)
+
+    // Render the bodies
+    this.context.strokeStyle = '#FFFFFF'
+    this.context.beginPath()
+    this.collisions.draw(this.context)
+    this.context.stroke()
+
+    // Render the BVH
+    if (this.wantsBvh) {
+      this.context.strokeStyle = '#00FF00'
+      this.context.beginPath()
+      this.collisions.drawBVH(this.context)
+      this.context.stroke()
+    }
+  }
+}
+
+function random(min: number, max: number): number {
+  return Math.floor(Math.random() * max) + min
+}

--- a/src/collisions/circles.ts
+++ b/src/collisions/circles.ts
@@ -53,6 +53,7 @@ export class GrowingCirclesTest {
   }
 
   createCircles(): void {
+    this.bodies.forEach(body => body.remove())
     this.bodies = []
     const circleCount = random(2, 8)
     const ratios = range(0, circleCount).map(() => random(10, 50))

--- a/src/collisions/index.ts
+++ b/src/collisions/index.ts
@@ -1,0 +1,9 @@
+import Vue from "vue"
+
+import CollisionsTest from './CollisionsTest.vue'
+
+new Vue({
+  el: '#app',
+  template: '<CollisionsTest/>',
+  render: h => h(CollisionsTest),
+})

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,12 +4,14 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 
 module.exports = {
-  entry: './src/index.ts',
+  entry: {
+    main: './src/index.ts',
+    collisions: './src/collisions/index.ts',
+  },
   output: {
     filename: 'bundle.[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
   },
-  devtool: "source-map",
   module: {
     rules: [
       {
@@ -64,6 +66,14 @@ module.exports = {
     new HtmlWebpackPlugin({
       title: "Gallifreyo · Gallifreyan Translator",
       template: './src/template.ejs',
+      filename: 'index.html',
+      chunks: ['main'],
+    }),
+    new HtmlWebpackPlugin({
+      title: "Gallifreyo · Collisions Test",
+      template: './src/template.ejs',
+      filename: 'collisions/index.html',
+      chunks: ['collisions'],
     }),
   ],
 };


### PR DESCRIPTION
I have come to the conclusion that the only viable method for word positioning and sizing is via a close-packing method rather than an angular positioning method. Angular positioning works //great// when all the words are of similar sizes, but as size disparity increases, aesthetics decreases. This is because angular positioning is, by definition, based on the centrepoint of the sentence circle, which does not elicit nearly enough flexibility. It will also cause huge difficulties when implementing tessellation down the line.

I'm going to stick with the angular method for letters for now, though, as they are all similar sizes and do not nearly as much flexibility as words. Also, to some extent, disparity works in their favour, visually.

-----

This PR will implement word positioning and sizing via a close-packing method, which will be visually optimised by iteratively growing/moving the word circles until they collide and can no longer be moved.

- [x] Set up a canvas test