### PR TITLE
Buffer circles

### DIFF
--- a/src/classes/Letter.ts
+++ b/src/classes/Letter.ts
@@ -1,12 +1,12 @@
 import { sum } from "lodash"
 
 import { Settings } from '@/types/state'
-import { Text } from '@/classes/Phrase'
+import { TextNode } from '@/classes/Phrase'
 import { Word } from '@/classes/Word'
 import { Subletter } from '@/types/phrases'
 import { circleIntersectionPoints } from '@/functions/geometry'
 
-export class Letter extends Text {
+export class Letter extends TextNode {
   depth: "letter"
   subletters: Subletter[]
   // Render properties
@@ -20,7 +20,7 @@ export class Letter extends Text {
     this.subletters = subletters
   }
 
-  render (word: Word, angleSubtendedByVowel: number): void {
+  draw (word: Word, angleSubtendedByVowel: number): void {
     /**
      * Generates the SVG path for a given letter and attaches it as letter.d.
      *

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -10,11 +10,12 @@ export abstract class TextNode {
   id: number
   settings: Settings
   angularLocation?: number
-  paths?: Path[]
+  paths: Path[]
 
   constructor (id: number, settings: Settings) {
     this.id = id
     this.settings = settings
+    this.paths = []
   }
 }
 
@@ -136,6 +137,18 @@ export abstract class Phrase extends TextNode {
       this.x = parent.x! + coords[0]
       this.y = parent.y! + coords[1]
     }
+
+    // Make a debug path to show the buffer
+    let bufferDebugPath = ""
+    bufferDebugPath += `M ${this.x} ${this.y}`
+    bufferDebugPath += `m ${-this.bufferRadius!} 0`
+    bufferDebugPath += `a ${this.bufferRadius} ${this.bufferRadius} 0 1 1 ${2 * this.bufferRadius!} 0`
+    bufferDebugPath += `a ${this.bufferRadius} ${this.bufferRadius} 0 1 1 ${-2 * this.bufferRadius!} 0`
+    this.paths.push({
+      d: bufferDebugPath,
+      type: 'debug',
+      purpose: 'circle',
+    })
   }
 
   addAngularLocation (

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -35,7 +35,6 @@ export abstract class Phrase extends TextNode {
   calculateGeometry (
     parent: Sentence,
     index: number,
-    relativeAngularSizeSum: number,
   ): void {
     /**
      * Calculates a phrase's geometry relative to its parent phrase. The parent
@@ -46,9 +45,6 @@ export abstract class Phrase extends TextNode {
      *
      * @param parent: The parent phrase.
      * @param index: The index of the subphrase in the parent phrase.
-     * @param structure: The algorithm to use for positioning and sizing.
-     * @param relativeAngularSizeSum: The sum of relative angles for all
-     * phrases and buffers in the parent phrase.
      * @returns void; Modifies the subphrase in place to add x, y, radius, and
      * angularLocation
      */

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -81,8 +81,7 @@ export abstract class Phrase extends TextNode {
 
       // Calculate the angle that this subphrase is at relative to its parent
       // phrase
-      // For sentences, this does include buffers
-      this.addAngularLocation(parent, index, relativeAngularSizeSum)
+      this.addAngularLocation(parent, index)
 
       // Calculate coordinates for transformation
       const translate = {
@@ -142,7 +141,6 @@ export abstract class Phrase extends TextNode {
   addAngularLocation (
     parent: Sentence,
     index: number,
-    relativeAngularSizeSum: number,
   ): void {
     /**
      * Set the angular location of this subphrase based on its position in the
@@ -150,8 +148,6 @@ export abstract class Phrase extends TextNode {
      *
      * @param parent: The sentence that contains this phrase.
      * @param index: The index of this letter in the word.
-     * @param relativeAngularSizeSum: The sum of all the relative anglular
-     * sizes in the parent sentence.
      */
     this.angularLocation = (
       parent.phrases.slice(0, index + 1).reduce(
@@ -161,8 +157,6 @@ export abstract class Phrase extends TextNode {
       )
       - (parent.phrases[0].absoluteAngularSize! / 2)
       - (this.absoluteAngularSize! / 2)
-      + (index * this.settings.config.buffer.phrase * 2 * Math.PI
-         / relativeAngularSizeSum)
     )
   }
 }

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -26,6 +26,7 @@ export abstract class Phrase extends TextNode {
   absoluteAngularSize?: number
   x?: number
   y?: number
+  bufferRadius?: number
   radius?: number
 
   constructor (id: number, settings: Settings) {
@@ -70,9 +71,11 @@ export abstract class Phrase extends TextNode {
           parent.radius! * Math.sin(radialSubtension)
           / (Math.sin(radialSubtension) + 1)
         )
-        this.radius = subphraseRadius
+        this.bufferRadius = subphraseRadius
+        this.radius = this.bufferRadius * this.settings.config.buffer.phrase
       } else {
-        this.radius = parent.radius!
+        this.bufferRadius = parent.radius!
+        this.radius = this.bufferRadius
       }
 
       // Calculate the angle that this subphrase is at relative to its parent
@@ -82,9 +85,9 @@ export abstract class Phrase extends TextNode {
       // Calculate coordinates for transformation
       const translate = {
         x: Math.cos(this.angularLocation! + Math.PI / 2) *
-          (-parent.radius! + this.radius!),
+          (-parent.radius! + this.bufferRadius!),
         y: Math.sin(this.angularLocation! + Math.PI / 2) *
-          (-parent.radius! + this.radius!),
+          (-parent.radius! + this.bufferRadius!),
       }
       this.x = parent.x! + translate.x
       this.y = parent.y! + translate.y
@@ -115,7 +118,8 @@ export abstract class Phrase extends TextNode {
       const targetSpiralRadius = parent.radius! / 2
       const multiplier = targetSpiralRadius / estimatedSpiralRadius
 
-      this.radius = multiplier/2
+      this.bufferRadius = multiplier/2
+      this.radius = this.bufferRadius * this.settings.config.buffer.phrase
       // why does it need to be /2 ???
       // because the multiplier is the length of the unit diameter
 

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -3,7 +3,7 @@ import { Settings } from '@/types/state'
 import { Sentence } from '@/classes/Sentence'
 import { getSpiralCoord } from '@/functions/geometry'
 
-export abstract class Text {
+export abstract class TextNode {
   /**
    * Base class for all written nodes.
    */
@@ -18,7 +18,7 @@ export abstract class Text {
   }
 }
 
-export abstract class Phrase extends Text {
+export abstract class Phrase extends TextNode {
   /**
    * Base class for sentences and words.
    */

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -72,7 +72,7 @@ export abstract class Phrase extends TextNode {
       if (parent.phrases.length > 1) {
         const subphraseRadius = (
           parent.radius! * Math.sin(radialSubtension)
-          / (this.settings.config.word.height * Math.sin(radialSubtension) + 1)
+          / (Math.sin(radialSubtension) + 1)
         )
         this.radius = subphraseRadius
       } else {
@@ -86,9 +86,9 @@ export abstract class Phrase extends TextNode {
       // Calculate coordinates for transformation
       const translate = {
         x: Math.cos(this.angularLocation! + Math.PI / 2) *
-          (-parent.radius! + (this.settings.config.word.height * this.radius!)),
+          (-parent.radius! + this.radius!),
         y: Math.sin(this.angularLocation! + Math.PI / 2) *
-          (-parent.radius! + (this.settings.config.word.height * this.radius!)),
+          (-parent.radius! + this.radius!),
       }
       this.x = parent.x! + translate.x
       this.y = parent.y! + translate.y

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -33,12 +33,10 @@ export class Sentence extends Phrase {
     // Assign normalised relative angles to each subphrase
     this.addRelativeAngularSizes()
 
-    // Calculate the sum of the relative angles, including buffers
-    // Note that this calculation includes buffers between letters, which at
-    // this point do not yet exist
+    // Calculate the sum of the relative angles
     const relativeAngularSizeSum = this.phrases.reduce((total, phrase) => {
       return total + phrase.relativeAngularSize!
-    }, 0) + (this.settings.config.buffer.phrase * this.phrases.length)
+    }, 0)
 
     // Convert relative angles to absolute angles (radians)
     this.addAbsoluteAngularSizes(relativeAngularSizeSum)
@@ -146,6 +144,8 @@ export class Sentence extends Phrase {
   addAbsoluteAngularSizes (relativeAngularSizeSum: number): void {
     /**
      * Convert relative angular sizes on subphrases to absolute angular sizes.
+     *
+     * TODO This will fail when the relative angular sizes do not average to 1.
      */
     this.phrases.forEach((phrase) => {
       phrase.absoluteAngularSize = (

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -17,8 +17,6 @@ export class Sentence extends Phrase {
   }
 
   draw (): void {
-    this.paths = []
-
     // If this sentence contains more than one subphrase, then draw a circle
     // around it
     if (this.phrases.length > 1) {

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -44,7 +44,7 @@ export class Sentence extends Phrase {
     // Assign positions and calculate the size of each subphrase, and then
     // render them
     this.phrases.forEach((phrase, index) => {
-      phrase.calculateGeometry(this, index, relativeAngularSizeSum)
+      phrase.calculateGeometry(this, index)
       phrase.draw()
     })
 
@@ -115,15 +115,9 @@ export class Sentence extends Phrase {
      * they average to 1.
      */
     this.phrases.forEach(phrase => {
-      if(Array.isArray(phrase.phrases)){
-        // This is a word
-        phrase.relativeAngularSize = Math.pow(
-          phrase.phrases.length, this.settings.config.sizeScaling
-        )
-      } else {
-        // This is a buffer
-        phrase.relativeAngularSize = this.settings.config.buffer.phrase
-      }
+      phrase.relativeAngularSize = Math.pow(
+        phrase.phrases.length, this.settings.config.sizeScaling
+      )
     })
 
     // Calculate the sum of the relative angles, excluding buffers

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -16,7 +16,7 @@ export class Sentence extends Phrase {
     this.radius = 100
   }
 
-  render (): void {
+  draw (): void {
     this.paths = []
 
     // If this sentence contains more than one subphrase, then draw a circle
@@ -47,7 +47,7 @@ export class Sentence extends Phrase {
     // render them
     this.phrases.forEach((phrase, index) => {
       phrase.calculateGeometry(this, index, relativeAngularSizeSum)
-      phrase.render()
+      phrase.draw()
     })
 
     // Make the debug paths for the subphrases

--- a/src/classes/Word.ts
+++ b/src/classes/Word.ts
@@ -14,7 +14,7 @@ export class Word extends Phrase {
     this.phrases = phrases
   }
 
-  render (): void {
+  draw (): void {
     // XXX a lot of this function is very similar to geometry.ts
 
     // Word already has x, y and radius from geometry.ts
@@ -49,7 +49,7 @@ export class Word extends Phrase {
       // Do not need to include buffer distance spefically, because the buffers
       // already exist as phantom letters
       letter.addAngularLocation(this, index)
-      letter.render(this, vowelAngularSize)
+      letter.draw(this, vowelAngularSize)
     })
   }
 

--- a/src/classes/Word.ts
+++ b/src/classes/Word.ts
@@ -17,9 +17,7 @@ export class Word extends Phrase {
   draw (): void {
     // XXX a lot of this function is very similar to geometry.ts
 
-    // Word already has x, y and radius from geometry.ts
-
-    this.paths = []
+    // Word already has x, y and radius from geometry.ts 
 
     // Assign relative angles and other letter-based properties to each
     // letter

--- a/src/functions/draw.ts
+++ b/src/functions/draw.ts
@@ -20,7 +20,7 @@ export function drawTokenisedInput(
   // this function; a top-level phrase that contains only paragraphs.
   tokenisedInput.forEach(sentence => {
     // Render it
-    sentence.render()
+    sentence.draw()
   })
   return tokenisedInput
 }

--- a/src/functions/draw.ts
+++ b/src/functions/draw.ts
@@ -1,9 +1,7 @@
-import { Settings } from '@/types/state'
 import { Sentence } from '@/classes/Sentence'
 
 export function drawTokenisedInput(
   tokenisedInput: Sentence[],
-  settings: Settings,
 ): Sentence[] {
   /**
    * Renders the tokenised input into an SVG image.

--- a/src/store.ts
+++ b/src/store.ts
@@ -51,7 +51,6 @@ export default new Vuex.Store({
           state.settings.selectedAlphabets,
           state.settings,
         ),
-        state.settings
       )
       fixBoundingBox()
     },

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,7 +33,6 @@ export default new Vuex.Store({
         d: { height: -0.4, width: 2 },
         f: { height: 0, width: 0.75 },
         v: { height: 2, width: 1, r: 0.1 },
-        word: { height: 1.2, width: 1 },
         buffer: { letter: 0.5, phrase: 0.3 },
         automatic: { scaledLessThan: 6, spiralMoreThan: 9 },
         sizeScaling: 0,

--- a/src/store.ts
+++ b/src/store.ts
@@ -33,7 +33,7 @@ export default new Vuex.Store({
         d: { height: -0.4, width: 2 },
         f: { height: 0, width: 0.75 },
         v: { height: 2, width: 1, r: 0.1 },
-        buffer: { letter: 0.5, phrase: 0.3 },
+        buffer: { letter: 0.5, phrase: 0.8 },
         automatic: { scaledLessThan: 6, spiralMoreThan: 9 },
         sizeScaling: 0,
         positionAlgorithm: 'Circular',

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -39,7 +39,6 @@ export type Config = {
   d: BlockConfig
   f: BlockConfig
   v: VowelBlockConfig
-  word: BlockConfig
   buffer: BufferConfig
   automatic: AutomaticConfig
   sizeScaling: number


### PR DESCRIPTION
Buffer letters were a solution that was appropiate for the temporary implementation of the radial algorithm. It is time for them to go. They should instead be replaced with buffer circles, which will occupy the full space allocated for a single phrase, and then the phrase itself will occupy a slightly smaller space inside that. This will create a margin around the phrase which should be sufficient to contain any offshoots. It'll certainly be more reliable than the current solution. However, it might come at the cost of making the radial positioning algorithm visually even worse - there's no way to be sure just yet.

I plan to use the radial positioning algorithm as a starting point for the organic positioning algorithm (#51). For this to be accurate, there should not be any buffer letters.

- [x] Scrap phrase buffers
- [x] Make phrases touch their sentence when the buffer is 0
- [x] (Radial) Make sure phrases still occupy the full circle
- [x] (Spiral) Make sure phrases still occupy the full spiral
- [x] Implement buffer circles
- [x] Move the green debug lines to the buffer circles