### PR TITLE
Abstract SVG path definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-preset-typescript-vue": "^1.1.1",
     "bulma": "^0.8.2",
     "clean-webpack-plugin": "^3.0.0",
+    "compress-tag": "^2.0.0",
     "core-js": "^3.6.5",
     "css-loader": "^3.5.3",
     "detect-collisions": "^2.5.2",

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -26,7 +26,11 @@ export abstract class TextNode {
     this.paths = []
   }
 
-  drawCircle (centre: Point, radius: number, intent: Intent): void {
+  drawCircle (
+    centre: Point,
+    radius: number,
+    intent: Intent = { type: 'default'},
+  ): void {
     /**
      * Draw a circle of a radius around a point.
      */
@@ -43,7 +47,7 @@ export abstract class TextNode {
     to: Point,
     radius: number,
     { largeArc, sweep }: { largeArc: boolean, sweep: boolean },
-    intent: Intent,
+    intent: Intent = { type: 'default'},
   ): void {
     /**
      * Draw a curve between two points of known radius.
@@ -55,7 +59,11 @@ export abstract class TextNode {
     this.paths.push({ d: path, ...intent })
   }
 
-  drawLine (from: Point, to: Point, intent: Intent): void {
+  drawLine (
+    from: Point,
+    to: Point,
+    intent: Intent = { type: 'default'},
+  ): void {
     /**
      * Draw a line between two points.
      */
@@ -188,16 +196,10 @@ export abstract class Phrase extends TextNode {
     }
 
     // Make a debug path to show the buffer
-    let bufferDebugPath = ""
-    bufferDebugPath += `M ${this.x} ${this.y}`
-    bufferDebugPath += `m ${-this.bufferRadius!} 0`
-    bufferDebugPath += `a ${this.bufferRadius} ${this.bufferRadius} 0 1 1 ${2 * this.bufferRadius!} 0`
-    bufferDebugPath += `a ${this.bufferRadius} ${this.bufferRadius} 0 1 1 ${-2 * this.bufferRadius!} 0`
-    this.paths.push({
-      d: bufferDebugPath,
-      type: 'debug',
-      purpose: 'circle',
-    })
+    this.drawCircle(
+      this, this.bufferRadius!,
+      { type: 'debug', purpose: 'circle' },
+    )
   }
 
   addAngularLocation (

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -97,14 +97,15 @@ export class Sentence extends Phrase {
 
       // Positional debug path: red lines to show the position of the phrase
       // relative to its parent and its radius
-      let subphrasePositionDebugPath = ""
-      subphrasePositionDebugPath += `M ${this.x} ${this.y} L ${phrase.x} ${phrase.y}`
-      subphrasePositionDebugPath += `m ${-phrase.radius!} 0 l ${2 * phrase.radius!} 0`
-      phrase.paths!.push({
-        d: subphrasePositionDebugPath,
-        type: 'debug',
-        purpose: 'position',
-      })
+      this.drawLine(
+        this, phrase,
+        { type: 'debug', purpose: 'position' },
+      )
+      this.drawLine(
+        { x: phrase.x - phrase.radius, y: phrase.y },
+        { x: phrase.x + phrase.radius, y: phrase.y },
+        { type: 'debug', purpose: 'position' },
+      )
     })
   }
 

--- a/src/classes/Sentence.ts
+++ b/src/classes/Sentence.ts
@@ -10,22 +10,13 @@ export class Sentence extends Phrase {
     super(id, settings)
     this.depth = 'sentence'
     this.phrases = phrases
-    // Initial geometry values, may be overridden later
-    this.x = 0
-    this.y = 0
-    this.radius = 100
   }
 
   draw (): void {
     // If this sentence contains more than one subphrase, then draw a circle
     // around it
     if (this.phrases.length > 1) {
-      let sentencePath = ""
-      sentencePath += `M ${this.x} ${this.y}`
-      sentencePath += `m -${this.radius} 0`
-      sentencePath += `a ${this.radius} ${this.radius} 0 1 1 ${2 * this.radius!} 0`
-      sentencePath += `a ${this.radius} ${this.radius} 0 1 1 ${-2 * this.radius!} 0`
-      this.paths.push({d: sentencePath, type: 'default'})
+      this.drawCircle(this, this.radius, { type: 'default' })
     }
 
     // Assign normalised relative angles to each subphrase
@@ -50,49 +41,59 @@ export class Sentence extends Phrase {
     this.phrases.forEach((phrase, index) => {
       // Angular debug path: blue lines to show the angle subtended by this
       // phrase
-      let subphraseAngularDebugPath = ""
       // XXX phrase.angularLocation CAN be undef (spiral)
       const subphraseAngularLocations = {
         start: {
-          x: this.x! + Math.sin(
+          x: this.x + Math.sin(
             phrase.angularLocation! - phrase.absoluteAngularSize! / 2
-          ) * this.radius!,
-          y: this.y! - Math.cos(
+          ) * this.radius,
+          y: this.y - Math.cos(
             phrase.angularLocation! - phrase.absoluteAngularSize! / 2
-          ) * this.radius!,
+          ) * this.radius,
         },
         end: {
-          x: this.x! + Math.sin(
+          x: this.x + Math.sin(
             phrase.angularLocation! + phrase.absoluteAngularSize! / 2
-          ) * this.radius!,
-          y: this.y! - Math.cos(
+          ) * this.radius,
+          y: this.y - Math.cos(
             phrase.angularLocation! + phrase.absoluteAngularSize! / 2
-          ) * this.radius!,
+          ) * this.radius,
         }
       }
-      subphraseAngularDebugPath += `M ${this.x} ${this.y} L ${subphraseAngularLocations.start.x} ${subphraseAngularLocations.start.y}`
-      subphraseAngularDebugPath += `M ${this.x} ${this.y} L ${subphraseAngularLocations.end.x} ${subphraseAngularLocations.end.y}`
-      const sizeMod = (index + 1) / 10
+      this.drawLine(
+        this, subphraseAngularLocations.start,
+        { type: 'debug', purpose: 'angle' },
+      )
+      this.drawLine(
+        this, subphraseAngularLocations.end,
+        { type: 'debug', purpose: 'angle' },
+      )
+      const sizeMod = (index + 1) / 20
       const angularDebugPathCurvePoints = {
         start: {
-          x: this.x! +
-            -(this.x! - subphraseAngularLocations.start.x) * sizeMod,
-          y: this.y! +
-            -(this.y! - subphraseAngularLocations.start.y) * sizeMod,
+          x: this.x - (this.x - subphraseAngularLocations.start.x) * sizeMod,
+          y: this.y - (this.y - subphraseAngularLocations.start.y) * sizeMod,
         },
         end: {
-          x: this.x! +
-            -(this.x! - subphraseAngularLocations.end.x) * sizeMod,
-          y: this.y! +
-            -(this.y! - subphraseAngularLocations.end.y) * sizeMod,
+          x: this.x - (this.x - subphraseAngularLocations.end.x) * sizeMod,
+          y: this.y - (this.y - subphraseAngularLocations.end.y) * sizeMod,
         }
       }
-      subphraseAngularDebugPath += `M ${angularDebugPathCurvePoints.start.x} ${angularDebugPathCurvePoints.start.y} A ${this.radius! * sizeMod} ${this.radius! * sizeMod} 0 ${phrase.absoluteAngularSize! > Math.PI ? "1" : "0"} 1 ${angularDebugPathCurvePoints.end.x} ${angularDebugPathCurvePoints.end.y}`
-      phrase.paths!.push({
-        d: subphraseAngularDebugPath,
-        type: 'debug',
-        purpose: 'angle',
-      })
+      this.drawArc(
+        angularDebugPathCurvePoints.start,
+        angularDebugPathCurvePoints.end,
+        this.radius * sizeMod,
+        { largeArc: phrase.absoluteAngularSize! > Math.PI, sweep: true },
+        { type: 'debug', purpose: 'angle' },
+      )
+      this.drawLine(
+        this, subphraseAngularLocations.start,
+        { type: 'debug', purpose: 'angle' },
+      )
+      this.drawLine(
+        this, subphraseAngularLocations.end,
+        { type: 'debug', purpose: 'angle' },
+      )
 
       // Positional debug path: red lines to show the position of the phrase
       // relative to its parent and its radius


### PR DESCRIPTION
Currently, whenever I want something to be drawn, I create a SVG path and append it to a list of paths which is stored on each phrase.

That approach isn't exactly future-proof. #55, for example, wants there to be two entirely separate drawing methods. Imperative declarations of low-level SVG code won't fly for that - at least not in the high-level code. Plus, writing so much low-level code repetitively is a pain, both for code duplication and for working out what stuff actually does. Abstracting it away has become not a necessity, but something that would be nice.

This is a requirement for #55, but right now, I don't care about building in compatibility for the canvas API.

- [x] Work out what kinds of SVG paths I need to abstract
- [x] Abstract them

Problem: I was going to have each call append another path to the stack, but that's not really how SVG paths are supposed to work - it's supposed to be one long path that covers all the bases. I'll have to try it with this simple method, though, and see if it causes any problems.