### PR TITLE
Dots

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/no-non-null-assertion": "off",
     "prefer-template": "error",
     "quotes": ["warn", "double"],
-    "comma-dangle": ["error", "always-multiline"]
+    "comma-dangle": ["error", "always-multiline"],
+    "no-void": "off"
   }
 }

--- a/src/classes/Letter.ts
+++ b/src/classes/Letter.ts
@@ -3,7 +3,7 @@ import { sum } from "lodash"
 import { Settings } from "../types/state"
 import { TextNode } from "../classes/Phrase"
 import { Word } from "../classes/Word"
-import { Subletter } from "../types/phrases"
+import { Subletter, Dot } from "../types/phrases"
 import { circleIntersectionPoints } from "../functions/geometry"
 
 export class Letter extends TextNode {
@@ -11,6 +11,7 @@ export class Letter extends TextNode {
   subletters: Subletter[]
   // Render properties
   height?: number
+  dots?: Dot[]
   // Drawing properties
   transform?: string
 

--- a/src/classes/Letter.ts
+++ b/src/classes/Letter.ts
@@ -287,13 +287,20 @@ export class Letter extends TextNode {
       { largeArc: angleSubtended > Math.PI, sweep: true },
       { type: "debug", purpose: "circle" },
     )
+
+    // Draw dots
+    this.dots.forEach(dot => {
+      this.drawCircle(dot, dot.radius)
+    })
   }
 
   /**
    * Generates dots for the letters that need them and adds them to the
    * letter's dots property.
+   *
+   * TODO Move debug line drawing to drawPath().
    */
-  drawDots (): void {
+  addDots (): void {
     const letter = this.subletters[0]
     const dotCount = letter.dots
     if (dotCount == null || dotCount === 0) {

--- a/src/classes/Phrase.ts
+++ b/src/classes/Phrase.ts
@@ -4,7 +4,7 @@ import { Path } from "../types/phrases"
 import { Settings } from "../types/state"
 import { Sentence } from "../classes/Sentence"
 
-type Point = { x: number, y: number }
+export type Point = { x: number, y: number }
 type Intent = {
   type: "default" | "debug"
   purpose?: "angle" | "position" | "circle"

--- a/src/classes/Word.ts
+++ b/src/classes/Word.ts
@@ -47,9 +47,9 @@ export class Word extends Phrase {
       letter.addAngularLocation(this, index)
       // Calculate rendering geometry
       letter.addGeometry(this, vowelAngularSize)
+      letter.addDots()
       // Draw the paths
       letter.drawPath(this)
-      letter.drawDots()
     })
   }
 

--- a/src/classes/Word.ts
+++ b/src/classes/Word.ts
@@ -43,12 +43,12 @@ export class Word extends Phrase {
     // Assign positions and calculate the size of each subphrase, and then
     // render them
     this.phrases.forEach((letter, index) => {
-      // XXX this is the same bit of code used in geometry; should consolidate
       // Sum the angles of the letters so far
-      // Do not need to include buffer distance spefically, because the buffers
-      // already exist as phantom letters
       letter.addAngularLocation(this, index)
-      letter.draw(this, vowelAngularSize)
+      // Calculate rendering geometry
+      letter.addGeometry(this, vowelAngularSize)
+      // Draw the main path
+      letter.drawPath(this)
     })
   }
 

--- a/src/classes/Word.ts
+++ b/src/classes/Word.ts
@@ -47,8 +47,9 @@ export class Word extends Phrase {
       letter.addAngularLocation(this, index)
       // Calculate rendering geometry
       letter.addGeometry(this, vowelAngularSize)
-      // Draw the main path
+      // Draw the paths
       letter.drawPath(this)
+      letter.drawDots()
     })
   }
 

--- a/src/components/RenderedLetter.vue
+++ b/src/components/RenderedLetter.vue
@@ -4,6 +4,12 @@
           :key="`path-${index}`"
           v-bind="path">
     </path>
+    <circle v-for="(dot, index) in letter.dots"
+            :key="`dot-${index}`"
+            :cx="dot.x"
+            :cy="dot.y"
+            :r="dot.radius">
+    </circle>
   </g>
 </template>
 

--- a/src/components/RenderedLetter.vue
+++ b/src/components/RenderedLetter.vue
@@ -8,7 +8,8 @@
             :key="`dot-${index}`"
             :cx="dot.x"
             :cy="dot.y"
-            :r="dot.radius">
+            :r="dot.radius"
+            fill="black">
     </circle>
   </g>
 </template>

--- a/src/components/RenderedLetter.vue
+++ b/src/components/RenderedLetter.vue
@@ -4,13 +4,6 @@
           :key="`path-${index}`"
           v-bind="path">
     </path>
-    <circle v-for="(dot, index) in letter.dots"
-            :key="`dot-${index}`"
-            :cx="dot.x"
-            :cy="dot.y"
-            :r="dot.radius"
-            fill="black">
-    </circle>
   </g>
 </template>
 

--- a/src/functions/alphabets.ts
+++ b/src/functions/alphabets.ts
@@ -63,13 +63,13 @@ const alphabets: AlphabetsData = {
     action: "create",
     letters: [
       { value: "CH", block: "s", dots: 2, lines: 0 },
-      { value: "WH", block: "p", dots: 1, lines: 0 },
+      { value: "PH", block: "p", dots: 1, lines: 0 },
+      { value: "WH", block: "d", dots: 1, lines: 0 },
       { value: "SH", block: "d", dots: 2, lines: 0 },
-      { value: "PH", block: "d", dots: 1, lines: 0 },
       { value: "TH", block: "f", dots: 0, lines: 0 },
       { value: "NG", block: "f", dots: 0, lines: 3 },
       { value: "QU", block: "f", dots: 0, lines: 1 },
-      { value: "GH", block: "f", dots: 1, lines: 3 },
+      { value: "GH", block: "f", dots: 1, lines: 0 },
     ],
   },
 }

--- a/src/functions/geometry.ts
+++ b/src/functions/geometry.ts
@@ -139,3 +139,16 @@ export function findAngle (a: Point, b: Point, c: Point): number {
   const ac = Math.sqrt(Math.pow(c.x - a.x, 2) + Math.pow(c.y - a.y, 2))
   return Math.acos((bc * bc + ab * ab - ac * ac) / (2 * bc * ab))
 }
+
+/**
+ * Finds the distance between two points.
+ *
+ * @param a - A point.
+ * @param b - The other points.
+ * @returns The distance as a positive number.
+ */
+export function distanceBetween (a: Point, b: Point): number {
+  const x = a.x - b.x
+  const y = a.y - b.y
+  return Math.sqrt(x * x + y * y)
+}

--- a/src/functions/geometry.ts
+++ b/src/functions/geometry.ts
@@ -1,3 +1,5 @@
+import { Point } from "../classes/Phrase"
+
 /**
  * Given parameters to form a spiral and select a point on it, returns the
  * coordinates of that point.
@@ -64,6 +66,7 @@ export function getSpiralCoord (
 /**
  * Calculates the points of intersection of two circles given their
  * coordinates and radii.
+ *
  * @param x0 - x-coordinate of the first circle.
  * @param y0 - y-coordinate of the first circle.
  * @param r0 - Radius of the first circle.
@@ -95,4 +98,44 @@ export function circleIntersectionPoints (
   const yiPrime = y2 - ry
   return [xi, xiPrime, yi, yiPrime]
   // xi is positive, xiPrime is negative for the word-letter situation
+}
+
+/**
+ * For a given circle and a point on it, find the point that is a certain
+ * distance from that point along the circle's circumference.
+ *
+ * @param centre - The coords of the centre of the circle.
+ * @param radius - The radius of the circle.
+ * @param point - The initial point on the circle.
+ * @param distance - The distance to travel along the circle. Not sure if it's
+ * clockwise or anticlockwise; if it's not the one you want, invert it.
+ */
+export function travelAlongCircle (
+  centre: Point,
+  radius: number,
+  point: Point,
+  distance: number,
+): Point {
+  const a = centre.x
+  const b = centre.y
+  const { x, y } = point
+  const theta = distance / radius
+  return {
+    x: a + (x - a) * Math.cos(theta) - (y - b) * Math.sin(theta),
+    y: b + (x - a) * Math.sin(theta) + (y - b) * Math.cos(theta),
+  }
+}
+
+/**
+ * Finds the angle between two points relative to a centre point.
+ *
+ * @param a - A point.
+ * @param b - The centre point.
+ * @param c - The other point.
+ */
+export function findAngle (a: Point, b: Point, c: Point): number {
+  const ab = Math.sqrt(Math.pow(b.x - a.x, 2) + Math.pow(b.y - a.y, 2))
+  const bc = Math.sqrt(Math.pow(b.x - c.x, 2) + Math.pow(b.y - c.y, 2))
+  const ac = Math.sqrt(Math.pow(c.x - a.x, 2) + Math.pow(c.y - a.y, 2))
+  return Math.acos((bc * bc + ab * ab - ac * ac) / (2 * bc * ab))
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -10,7 +10,9 @@ export default {
     phrases: [],
     settings: {
       splits: ["\n\n", "\n", " "],
-      selectedAlphabets: ["base", "Sherman", "ShermanVowels"],
+      selectedAlphabets: [
+        "base", "Sherman", "ShermanVowels", "ShermanDoubles",
+      ],
       scaling: true, // sentence size scaling
       watermark: true,
       debug: false,
@@ -30,7 +32,7 @@ export default {
         automatic: { scaledLessThan: 6, spiralMoreThan: 9 },
         sizeScaling: 1,
         positionAlgorithm: "Automatic",
-        dots: { sizeScaling: 1, radiusDifference: 0.9, size: 2, spacing: 1 },
+        dots: { sizeScaling: 1, radiusDifference: 0.9, size: 1.5, spacing: 1 },
       },
     },
   } as State,

--- a/src/store.ts
+++ b/src/store.ts
@@ -30,6 +30,7 @@ export default {
         automatic: { scaledLessThan: 6, spiralMoreThan: 9 },
         sizeScaling: 1,
         positionAlgorithm: "Automatic",
+        dots: { sizeScaling: 1, radiusDifference: 0.9, size: 2, spacing: 1 },
       },
     },
   } as State,

--- a/src/types/phrases.ts
+++ b/src/types/phrases.ts
@@ -14,7 +14,7 @@ import { LetterData } from "../types/alphabets"
  * During tokenisation, these properties will not exist.
  */
 
-export interface Path {
+export type Path = {
   d: string
   type: "default" | "debug"
   purpose?: "angle" | "position" | "circle"
@@ -27,4 +27,10 @@ export type Subletter = LetterData & {
   full?: boolean // Circle is full or cut off by word line
   relativeAngularSize?: number
   absoluteAngularSize?: number
+}
+
+export type Dot = {
+  x: number
+  y: number
+  radius: number
 }

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -33,7 +33,7 @@ export type Settings = {
   config: Config
 }
 
-export type Config = {
+type Config = {
   s: BlockConfig
   p: BlockConfig
   d: BlockConfig
@@ -43,26 +43,44 @@ export type Config = {
   automatic: AutomaticConfig
   sizeScaling: number
   positionAlgorithm: "Automatic" | "Radial" | "Organic" | "Spiral"
+  dots: DotConfig
 }
 
-export type BlockConfig = {
+type BlockConfig = {
   height: number // Height of this letter above (inside) the word circle
   width: number // The base relativeAngularSize for a letter in this block
 }
 
-export type VowelBlockConfig = BlockConfig & {
+type VowelBlockConfig = BlockConfig & {
   // What is r???????
   r: number
 }
 
-export type BufferConfig = {
+type BufferConfig = {
   letter: number
   word: number
   sentence: number
 }
 
-export type AutomaticConfig = {
+type AutomaticConfig = {
   // The naming scheme here is terrible
   scaledLessThan: number
   spiralMoreThan: number
+}
+
+/**
+ * Configuration for dots on dotted letters.
+ *
+ * @property sizeScaling - The degree to which dot sizes vary.
+ * @property radiusDifference - The difference between the radius of a letter
+ * and the radius of the implicit dot circle, expressed as a fraction of the
+ * average radius of all letters in this word.
+ * @property size - The size of a dot as a fraction of the base line width.
+ * @property spacing - The distance between dots as TODO.
+ */
+type DotConfig = {
+  sizeScaling: number
+  radiusDifference: number
+  size: number
+  spacing: number
 }


### PR DESCRIPTION
In #64 I concluded that it'd probably be easier to start with dots before I try to implement lines.

The [guide](https://shermansplanet.com/gallifreyan/guide.pdf) seems to have 4 different implicit dot settings:

<table>
	<tbody>
		<tr>
			<td></td>
			<td></td>
			<th colspan="2">Size variance</th>
		</tr>
		<tr>
			<td></td>
			<td></td>
			<th>Varied</th>
			<th>Static</th>
		</tr>
		<tr>
			<th rowspan="2">Side</th>
			<th>Centre</th>
			<td><img width="70" src="https://user-images.githubusercontent.com/29130152/107019999-3e226c80-679a-11eb-8bc2-63d0fa1283ee.png"></td>
			<td><img width="70" src="https://user-images.githubusercontent.com/29130152/107021059-960da300-679b-11eb-98e8-937fc6ef93f9.png"></td>
		</tr>
		<tr>
			<th>Side</th>
			<td><img width="70" src="https://user-images.githubusercontent.com/29130152/107020270-922d5100-679a-11eb-83cf-37aea2c6f611.png"></td>
			<td><img width="70" src="https://user-images.githubusercontent.com/29130152/107020673-1089f300-679b-11eb-996b-159f62b10320.png"></td>
		</tr>
	</tbody>
</table>

Although looking at it... different rules probably apply to each block. Let's see if I can't work out a standard solution for each block. Note that in addition to this, the sentence itself can have dots for punctuation, but we'll get to that later (#3).

Block | Dot placement
--- | ---
v | No dots.
s | Dots always appear inside the circle. They can be at any angle relative to the letter, provided that they do not cross the letter's gap in the word circle.
p | Dots always appear inside the circle. They can be at any angle relative to the letter. They typically do not vary in size.
d | Dots can appear either inside or outside the circle, but are consistent within a given sentence. If they appear inside the circle (i.e. on the outside of the word), when another word is nested into that d-site (#16), they appear in the gap between the two words. If the dots in a sentence vary in size, they tend to appear outside the circle. Dots almost always appear at one side of the letter curve, regardless of whether they are inside or outside it.
f | Dots always appear inside the circle. They can be at any angle relative to the letter, provided that they do not intersect the word circle.

Tasks for this PR:

- [ ] Draw dots
- [ ] Add an option that enables size variance

Closes #43.

Test phrase: `chd dadedidodu phklc cacecicocu whshr rareriroru ghyzq qaqeqiqoqu`